### PR TITLE
feat: Add GitHub workflow for PR reviews

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,36 @@
+name: PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  gemini-review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/run-gemini-cli@v0
+        with:
+          command: 'review'
+        env:
+          # This secret is required for the Gemini review.
+          # You can get a key from Google AI Studio.
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+
+  coderabbit-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Coderabbit Review
+        uses: coderabbitai/coderabbit-action@v1
+        with:
+          # This secret is required for the Coderabbit review.
+          # You can get a key from your Coderabbit dashboard.
+          CODERABBIT_API_KEY: ${{ secrets.CODERABBIT_API_KEY }}


### PR DESCRIPTION
This commit adds a new GitHub workflow that runs on pull requests. The workflow includes two jobs:
- gemini-review: Uses the official Google Gemini GitHub Action to review the code.
- coderabbit-review: Uses the Coderabbit GitHub Action to review the code.

Both jobs require API keys to be set as secrets in the repository. The workflow file includes comments to guide the user in setting up the necessary secrets.